### PR TITLE
明るさの値をuint8_tからfloatに変更

### DIFF
--- a/src/application/domain/model/brightness.cpp
+++ b/src/application/domain/model/brightness.cpp
@@ -9,15 +9,15 @@ namespace domain::model {
  * @brief 明るさオブジェクトを構築する
  * @param value 明るさの値
  */
-Brightness::Brightness(const uint8_t value) {
+Brightness::Brightness(const float value) {
   mValue = value;
 }
 
 /**
  * @brief 明るさの値を取得します。
- * @return uint8_t 現在の明るさの値
+ * @return float 現在の明るさの値
  */
-[[nodiscard]] uint8_t Brightness::getValue() const noexcept {
+[[nodiscard]] float Brightness::getValue() const noexcept {
   return mValue;
 }
 
@@ -25,7 +25,7 @@ Brightness::Brightness(const uint8_t value) {
  * @brief 明るさを設定する
  * @param value 設定する明るさの値 (0-100)
  */
-void Brightness::setValue(const uint8_t value) {
+void Brightness::setValue(const float value) {
   mValue = value;
 }
 

--- a/src/application/domain/model/brightness.hpp
+++ b/src/application/domain/model/brightness.hpp
@@ -21,7 +21,7 @@ public:
      * @brief 値を指定するコンストラクタ
      * @param value 設定する明るさの値
      */
-    explicit Brightness(uint8_t value);
+    explicit Brightness(float value);
 
     /**
      * @brief デストラクタ
@@ -38,21 +38,21 @@ public:
 
     /**
      * @brief 明るさの値を取得します。
-     * @return uint8_t 現在の明るさの値
+     * @return float 現在の明るさの値
      */
-    [[nodiscard]] uint8_t getValue() const noexcept;
+    [[nodiscard]] float getValue() const noexcept;
 
     /**
      * @brief 明るさの値を設定します。
      * @param value 設定する明るさの値
      */
-    void setValue(uint8_t value);
+    void setValue(float value);
 
 private:
     /**
      * @brief 明るさの値
      */
-    uint8_t mValue;
+    float mValue;
 
     };
 


### PR DESCRIPTION
## 変更内容
Issue #10 に対応し、Brightnessクラスの値の型をuint8_tからfloatに変更しました。

## 変更点
- Brightnessクラスの保持する値（mValue）の型をuint8_tからfloatに変更
- コンストラクタとsetValue()メソッドのパラメータ型をuint8_tからfloatに変更

## 関連Issue
Closes #10